### PR TITLE
tmback image switched to a new v0.0.3 tag

### DIFF
--- a/helm-charts/triggermesh/values.yaml
+++ b/helm-charts/triggermesh/values.yaml
@@ -42,7 +42,7 @@ backend:
   baseHost: app.tm.demo.vshn.net
   replicaCount: 3
   image: triggermesh/tmback
-  tag: v0.0.2
+  tag: v0.0.3
   paths:
     - /stats
     - /register


### PR DESCRIPTION
tmback image changelog:
- `ubi-minimal` base image triggermesh/ghbackend#169
- got rid of `clusterbuildtemplate` clusterrole(binding) in ghbackend 